### PR TITLE
Dns 001

### DIFF
--- a/nixos/config/common/default.nix
+++ b/nixos/config/common/default.nix
@@ -1,5 +1,8 @@
 {...}: {
-  imports = [./users.nix];
+  imports = [
+    ./users.nix
+    ./server.nix
+  ];
   nix = {
     # Optimisation of the Nix Store
     optimise.automatic = true;

--- a/nixos/config/common/server.nix
+++ b/nixos/config/common/server.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.server;
+in {
+  options.server = {
+    domain = mkOption {
+      type = types.str;
+      default = "middleearth.samlockart.com";
+      description = "The base domain for internal services (used with wildcard ACME cert)";
+    };
+  };
+}

--- a/nixos/config/secrets/rekeyed/sauron/8e241719324c883570366ef3454e2b0e-cloudflare-api-token.age
+++ b/nixos/config/secrets/rekeyed/sauron/8e241719324c883570366ef3454e2b0e-cloudflare-api-token.age
@@ -1,0 +1,17 @@
+age-encryption.org/v1
+-> ssh-rsa ka6+Gg
+bOuXvZuuJhi3B+xCa7vSBSHnBEo0KEko8l/+E0kZNELqVq/O8oVllAusprD4T4bZ
+bfEOZM0t9fmeSJNxWuUrNQut2qQEbN+HTXRzMfg9C/a383gN56skD5iAkYqx0PlO
+sHgyEkbpGsQce3DH3bV5HKOvv+wPj7pBhWKnDpHskE5NdT+/FEFutRALBA3hUgIs
+JEZhdXS4IUvRjIhRTPK7/8rUYNjhWgPNS1ucttyH3qGnEampQIzkIc1pk6vYBlfZ
+98OKi/HbcI36PBKYZXiHgJxqAZ0GlFtYo3sJuBP5A2zogmQbrMpaeObht0JM8drw
+OMSsq08srn2DpjxZK2D1WNjpXZ4fjzZwsy4Jxmaci35Bd8bcLNeJ+2oQWcMlmGBm
+G9pJNqrMqdiCb6d/unhplZf/Q5BDpGVYZ2zgS/aWUPmWlj78zaaHDNrDUQ7BxiYK
+5RKX+Gdqi4++gY1i+XLOo7Moy6Ga2VusrEupzKDQ/X2tYi9T9QS20djZhDthGs1O
+nt+NfSdhm6Ns4OP1PmPoawF6dbGkh9nU7SX/NWdR5AgpQioQu6f8LnxvRx7MTRB6
+dHI/ulZthVH057y0pMDV3d+7V3Jx7PUaJxFMhsEYl1X9US8B6nxEqwW9itIbMb7F
+YMznIN5FNHby8CRvKbLRKZh2xQxLhW5puMSZHQ4DZ6E
+-> vNma|Pe-grease /_qGY(W s"97
+RWAhPzgNxA
+--- YZgUFgJDSUbrzC9PMpld6Ek4IjvzO0EPyrAiwiEfyfc
+A—U³Ûa-Vâ†ól†é´A¹:êQÀfvÑ›èX2,f–ÐñúÂ‘Ïd,9‡EùMb=4Z”Ì§ÚéžwiNãõz	Q/Ñ ¦šû»¶6ë¨j>-¡4×ü—ôEn

--- a/nixos/sauron/maubot/default.nix
+++ b/nixos/sauron/maubot/default.nix
@@ -17,7 +17,9 @@ in {
   services.nginx = let
     inherit (config.services.maubot) settings;
   in {
-    virtualHosts."maubot.middleearth.samlockart.com" = {
+    virtualHosts."maubot.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:${toString settings.server.port}";
         proxyWebsockets = true;

--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -20,49 +20,49 @@ in {
         recommendedProxySettings = true;
       };
     };
-    virtualHosts."tv.middleearth.samlockart.com" = {
-      forceSSL = false;
-      enableACME = false;
+    virtualHosts."tv.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:8096";
         recommendedProxySettings = true;
       };
     };
-    virtualHosts."sonarr.middleearth.samlockart.com" = {
-      forceSSL = false;
-      enableACME = false;
+    virtualHosts."sonarr.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:8989";
         recommendedProxySettings = true;
       };
     };
-    virtualHosts."jackett.middleearth.samlockart.com" = {
-      forceSSL = false;
-      enableACME = false;
+    virtualHosts."jackett.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:9117";
         recommendedProxySettings = true;
       };
     };
-    virtualHosts."bazarr.middleearth.samlockart.com" = {
-      forceSSL = false;
-      enableACME = false;
+    virtualHosts."bazarr.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:${toString config.services.bazarr.listenPort}";
         recommendedProxySettings = true;
       };
     };
-    virtualHosts."radarr.middleearth.samlockart.com" = {
-      forceSSL = false;
-      enableACME = false;
+    virtualHosts."radarr.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:7878";
         recommendedProxySettings = true;
       };
     };
-    virtualHosts."lidarr.middleearth.samlockart.com" = {
-      forceSSL = false;
-      enableACME = false;
+    virtualHosts."lidarr.${cfg.domain}" = {
+      forceSSL = true;
+      useACMEHost = cfg.domain;
       locations."/" = {
         proxyPass = "http://127.0.0.1:${toString config.services.lidarr.settings.server.port}";
       };

--- a/nixos/sauron/monitoring/default.nix
+++ b/nixos/sauron/monitoring/default.nix
@@ -12,15 +12,15 @@ in {
     enable = true;
     settings = {
       server = {
-        domain = "grafana.middleearth.samlockart.com";
-        root_url = "http://${toString config.services.grafana.settings.server.domain}/";
+        domain = "grafana.${cfg.domain}";
+        root_url = "https://${toString config.services.grafana.settings.server.domain}/";
         protocol = "http";
         http_port = 3000;
         http_addr = "127.0.0.1";
         serve_from_sub_path = false;
       };
       security = {
-        cookie_secure = false; # serving via https proxy
+        cookie_secure = true; # serving via https proxy
       };
       smtp = {
         enabled = true;
@@ -33,8 +33,8 @@ in {
   };
 
   services.nginx.virtualHosts.${toString config.services.grafana.settings.server.domain} = {
-    forceSSL = false;
-    enableACME = false;
+    forceSSL = true;
+    useACMEHost = cfg.domain;
     locations = {
       "/" = {
         proxyPass = "${toString config.services.grafana.settings.server.protocol}://${toString config.services.grafana.settings.server.http_addr}:${toString config.services.grafana.settings.server.http_port}";

--- a/nixos/sauron/nginx/cloudflare-api-token.age
+++ b/nixos/sauron/nginx/cloudflare-api-token.age
@@ -1,12 +1,12 @@
 age-encryption.org/v1
--> X25519 4YZPF6cH4HBNIj2Tn0ZWNqGmwH0xz2goG8HS8P/1/UI
-qFgDpuYcLur3StQoOEx9ScMVT15Pl2YaMsF2LoJSX7Y
--> X25519 EnyT+HhEgH3p+4LnrLdDD0SHN1xqGGVgBRWlaau3OmI
-fqj5MdhzOxkeaOmaK5Svok1udnuIbsYrFlcZtW6HcNQ
--> X25519 ri2FEJnWynLRRcOsXa2h/feURhLhlB3MMnVCmYIogwI
-mgyy7IS2XszP5c9X8Iz4GkkMoYbqibQRpkqwg6ZIzNI
--> 4D-grease
-eA5Ae96qWX1YNN7AlRE8gYOzuV4Ads/DXmOCnOKK+2i29cvC0fG4dXA
---- /0B1EeOgaIfSZ97obI67n3PG+DlAah6tFexA08W4a3c
-¬Dl1ö‚€3Ñ˜Tb=1¢Ð:rB¯Ô|…’¸+%ÛñÑcñNÍ vù6|+KRä¦búpáùàõ
-`¹Þy‹¨%¬¶ÑCxÂL™Ì8=íyÿÙkNƒqÅhk}¸ 
+-> X25519 WzBmhLxVyC7hr5QSQUJcoiyTvIwfFxlF08EqJlKVRRc
+mtYGFxRWDSFIB81LOpXnz959QZw47tRHswGpEuREoMo
+-> X25519 5f/bhsYhaesn3q6O8OFn9DP/goItpODTiUbw6JHWZ1E
+/GPJRR9kyPbIg4m4t12/8RARE9beXDyweH/QMvD0y4I
+-> X25519 7cXdBfaqZ3uUN+9cYt6VAIDMSNSk+6o4gWOZBZ3iSDo
++gt37xe+IWJSsA91zWCvZ8SOm3yGCHIPFxHyEU7vTdk
+-> *r-grease
+HylNlsd5
+--- baBe4aODB9OaFLoi7xe5gMgTBMBII8LgSmedKFdA0pw
+°]™&~P/>SnsÄõ*œi•õÌØ.ž¤®8°g½ínBÝöf{K.èQˆ™j–mRÅ–~ú÷¼rêùTÆ3ÈÀ•^˜ÂqCæÅT¸[bÆ&!2Ö
+Ü‘—y¿)UMÈµ

--- a/nixos/sauron/nginx/cloudflare-api-token.age
+++ b/nixos/sauron/nginx/cloudflare-api-token.age
@@ -1,0 +1,12 @@
+age-encryption.org/v1
+-> X25519 4YZPF6cH4HBNIj2Tn0ZWNqGmwH0xz2goG8HS8P/1/UI
+qFgDpuYcLur3StQoOEx9ScMVT15Pl2YaMsF2LoJSX7Y
+-> X25519 EnyT+HhEgH3p+4LnrLdDD0SHN1xqGGVgBRWlaau3OmI
+fqj5MdhzOxkeaOmaK5Svok1udnuIbsYrFlcZtW6HcNQ
+-> X25519 ri2FEJnWynLRRcOsXa2h/feURhLhlB3MMnVCmYIogwI
+mgyy7IS2XszP5c9X8Iz4GkkMoYbqibQRpkqwg6ZIzNI
+-> 4D-grease
+eA5Ae96qWX1YNN7AlRE8gYOzuV4Ads/DXmOCnOKK+2i29cvC0fG4dXA
+--- /0B1EeOgaIfSZ97obI67n3PG+DlAah6tFexA08W4a3c
+¬Dl1ö‚€3Ñ˜Tb=1¢Ð:rB¯Ô|…’¸+%ÛñÑcñNÍ vù6|+KRä¦búpáùàõ
+`¹Þy‹¨%¬¶ÑCxÂL™Ì8=íyÿÙkNƒqÅhk}¸ 

--- a/nixos/sauron/nginx/default.nix
+++ b/nixos/sauron/nginx/default.nix
@@ -9,7 +9,7 @@
   allVhosts = builtins.attrNames config.services.nginx.virtualHosts;
   middleearthVhosts =
     builtins.filter
-    (name: lib.hasSuffix ".middleearth.samlockart.com" name)
+    (name: lib.hasSuffix ".${cfg.domain}" name)
     allVhosts;
   tailscaleVhosts = config.services.nginx.tailscaleAuth.virtualHosts;
   missingVhosts =
@@ -21,7 +21,7 @@ in {
     {
       assertion = missingVhosts == [];
       message = ''
-        The following middleearth.samlockart.com virtualHosts are not protected by tailscaleAuth:
+        The following ${cfg.domain} virtualHosts are not protected by tailscaleAuth:
           ${lib.concatStringsSep "\n    " missingVhosts}
         Add them to services.nginx.tailscaleAuth.virtualHosts in nginx.nix
       '';
@@ -40,12 +40,12 @@ in {
   security.acme.defaults.email = "sam@samlockart.com";
   security.acme.acceptTerms = true;
 
-  age.secrets.cloudflare-api-token = ./cloudflare-api-token.age;
+  age.secrets.cloudflare-api-token.rekeyFile = ./cloudflare-api-token.age;
 
   security.acme = {
     certs = {
-      "middleearth.samlockart.com" = {
-        domain = "*.middleearth.samlockart.com";
+      "${cfg.domain}" = {
+        domain = "*.${cfg.domain}";
         group = "nginx";
         dnsProvider = "cloudflare";
         # location of your CLOUDFLARE_DNS_API_TOKEN=[value]
@@ -70,17 +70,17 @@ in {
     tailscaleAuth = {
       enable = true;
       virtualHosts = [
-        "jackett.middleearth.samlockart.com"
-        "sonarr.middleearth.samlockart.com"
-        "radarr.middleearth.samlockart.com"
-        "bazarr.middleearth.samlockart.com"
-        "lidarr.middleearth.samlockart.com"
-        "open-webui.middleearth.samlockart.com"
-        "maubot.middleearth.samlockart.com"
-        "sync.middleearth.samlockart.com"
-        "transmission.middleearth.samlockart.com"
-        "grafana.middleearth.samlockart.com"
-        "tv.middleearth.samlockart.com"
+        "jackett.${cfg.domain}"
+        "sonarr.${cfg.domain}"
+        "radarr.${cfg.domain}"
+        "bazarr.${cfg.domain}"
+        "lidarr.${cfg.domain}"
+        "open-webui.${cfg.domain}"
+        "maubot.${cfg.domain}"
+        "sync.${cfg.domain}"
+        "transmission.${cfg.domain}"
+        "grafana.${cfg.domain}"
+        "tv.${cfg.domain}"
       ];
     };
 

--- a/nixos/sauron/nginx/default.nix
+++ b/nixos/sauron/nginx/default.nix
@@ -125,6 +125,23 @@ in {
       # proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
     '';
 
+    # Localhost-only status endpoint for prometheus nginx exporter
+    virtualHosts."localhost" = {
+      listen = [
+        { addr = "127.0.0.1"; port = 80; }
+        { addr = "[::1]"; port = 80; }
+      ];
+      locations."/nginx_status" = {
+        extraConfig = ''
+          stub_status on;
+          access_log off;
+          allow 127.0.0.1;
+          allow ::1;
+          deny all;
+        '';
+      };
+    };
+
     virtualHosts."www.iced.cool" = {
       # catch all
       forceSSL = true;

--- a/nixos/sauron/nginx/default.nix
+++ b/nixos/sauron/nginx/default.nix
@@ -40,6 +40,21 @@ in {
   security.acme.defaults.email = "sam@samlockart.com";
   security.acme.acceptTerms = true;
 
+  age.secrets.cloudflare-api-token = ./cloudflare-api-token.age;
+
+  security.acme = {
+    certs = {
+      "middleearth.samlockart.com" = {
+        domain = "*.middleearth.samlockart.com";
+        group = "nginx";
+        dnsProvider = "cloudflare";
+        # location of your CLOUDFLARE_DNS_API_TOKEN=[value]
+        # https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=
+        environmentFile = config.age.secrets.cloudflare-api-token.path;
+      };
+    };
+  };
+
   ## services
   services.tailscaleAuth = {
     enable = true;

--- a/nixos/sauron/openwebui/default.nix
+++ b/nixos/sauron/openwebui/default.nix
@@ -18,9 +18,9 @@ in {
     };
   };
 
-  services.nginx.virtualHosts."open-webui.middleearth.samlockart.com" = {
-    forceSSL = false;
-    enableACME = false;
+  services.nginx.virtualHosts."open-webui.${cfg.domain}" = {
+    forceSSL = true;
+    useACMEHost = cfg.domain;
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString config.services.open-webui.port}";
       recommendedProxySettings = true;

--- a/nixos/sauron/syncthing/default.nix
+++ b/nixos/sauron/syncthing/default.nix
@@ -45,9 +45,9 @@ in {
     };
   };
 
-  services.nginx.virtualHosts."sync.middleearth.samlockart.com" = {
-    forceSSL = false;
-    enableACME = false;
+  services.nginx.virtualHosts."sync.${cfg.domain}" = {
+    forceSSL = true;
+    useACMEHost = cfg.domain;
     locations."/" = {
       proxyPass = "http://127.0.0.1:8384";
     };

--- a/nixos/sauron/transmission/default.nix
+++ b/nixos/sauron/transmission/default.nix
@@ -15,9 +15,9 @@ in {
   networking.firewall.allowedTCPPorts = [config.services.transmission.settings.peer-port];
   networking.firewall.allowedUDPPorts = [config.services.transmission.settings.peer-port];
 
-  services.nginx.virtualHosts."transmission.middleearth.samlockart.com" = {
-    forceSSL = false;
-    enableACME = false;
+  services.nginx.virtualHosts."transmission.${cfg.domain}" = {
+    forceSSL = true;
+    useACMEHost = cfg.domain;
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString config.services.transmission.settings.rpc-port}";
     };


### PR DESCRIPTION
This pull request introduces a centralized and configurable domain setting for internal services, improving maintainability and security by switching to wildcard ACME certificates with DNS validation via Cloudflare. All relevant Nginx virtual hosts and related configurations now reference a single domain variable, enforce HTTPS, and use secure cookies where appropriate. Additionally, secrets management for Cloudflare API tokens is added, and a localhost-only status endpoint for Prometheus monitoring is introduced.

**Domain configuration and centralization:**
- Added a new `server.domain` option in `server.nix` (defaulting to `middleearth.samlockart.com`), and updated `default.nix` to import this configuration, allowing all services to reference a single domain variable. [[1]](diffhunk://#diff-4e717df659368a67bb0ad82a467f125fc46e251b6a036c87d7d7cbbfbfc02684R1-R16) [[2]](diffhunk://#diff-d27638ce0bce69e4f8f4ef91d5059fb3b2c82571f0572084898c141f10d15e63L2-R5)
- Refactored all Nginx virtual hosts and related service configurations to use `"${cfg.domain}"` instead of hardcoding the domain, improving maintainability and consistency across the codebase. [[1]](diffhunk://#diff-dc7f1794646466af08a6e1be2d2a013d90e24212ab54b8fef0e02bad8ae5bca2L23-R65) [[2]](diffhunk://#diff-3a457122fa277ef889a9b1079ad4f8a685f0c92a5415ddab00dc0767db2e5c6dL20-R22) [[3]](diffhunk://#diff-5db6c5dee8a9ab2fbcf59e8a14a7e4aed1de524ae8c4fbf4ac02eeef05d13713L15-R23) [[4]](diffhunk://#diff-5db6c5dee8a9ab2fbcf59e8a14a7e4aed1de524ae8c4fbf4ac02eeef05d13713L36-R37) [[5]](diffhunk://#diff-ebace772ea5962848ed8cf03baeee4ef0604b258c17e2ab8f3d5a80b58820acbL21-R23) [[6]](diffhunk://#diff-57de88777656a96054214b3d4dbf156c2957efa00bc09bf5ec169a0762482641L48-R50) [[7]](diffhunk://#diff-60f638831adb25981f0ab1a161423dcc03e30815905969db7056e0d5b3d33870L18-R20) [[8]](diffhunk://#diff-89c16dcc54560991e39b257c3917c6a154a2068a45276d960258521d8fa51c9bL12-R12) [[9]](diffhunk://#diff-89c16dcc54560991e39b257c3917c6a154a2068a45276d960258521d8fa51c9bL24-R24) [[10]](diffhunk://#diff-89c16dcc54560991e39b257c3917c6a154a2068a45276d960258521d8fa51c9bL58-R83)

**Security and HTTPS improvements:**
- All internal service virtual hosts now enforce HTTPS (`forceSSL = true`) and use ACME certificates via the new `useACMEHost` parameter, replacing the previous `enableACME = false` pattern. [[1]](diffhunk://#diff-dc7f1794646466af08a6e1be2d2a013d90e24212ab54b8fef0e02bad8ae5bca2L23-R65) [[2]](diffhunk://#diff-3a457122fa277ef889a9b1079ad4f8a685f0c92a5415ddab00dc0767db2e5c6dL20-R22) [[3]](diffhunk://#diff-5db6c5dee8a9ab2fbcf59e8a14a7e4aed1de524ae8c4fbf4ac02eeef05d13713L36-R37) [[4]](diffhunk://#diff-ebace772ea5962848ed8cf03baeee4ef0604b258c17e2ab8f3d5a80b58820acbL21-R23) [[5]](diffhunk://#diff-57de88777656a96054214b3d4dbf156c2957efa00bc09bf5ec169a0762482641L48-R50) [[6]](diffhunk://#diff-60f638831adb25981f0ab1a161423dcc03e30815905969db7056e0d5b3d33870L18-R20)
- Grafana and other services now set `cookie_secure = true` to ensure cookies are only sent over secure connections.

**Wildcard ACME certificate and Cloudflare DNS integration:**
- Configured Nginx to use a wildcard ACME certificate for `"*.${cfg.domain}"` with DNS validation via Cloudflare, and added secret management for the Cloudflare API token using `age`. [[1]](diffhunk://#diff-89c16dcc54560991e39b257c3917c6a154a2068a45276d960258521d8fa51c9bR43-R57) [[2]](diffhunk://#diff-a033d1c32d744c1289dc8e8c4b34f10d238430e634de6da67509ab747dffa9cfR1-R12) [[3]](diffhunk://#diff-02bd64ecd5594c62072cf60c9c0284f30fa9f60a189d4ab08e9996a0b895f249R1-R17)

**Monitoring and observability:**
- Added a localhost-only Nginx status endpoint at `/nginx_status` for Prometheus monitoring, restricted to local access only.

**Tailscale authentication updates:**
- Updated the list of Tailscale-protected virtual hosts to use the new domain variable, ensuring all relevant services remain protected after the domain centralization.

These changes collectively improve security, simplify domain management, and enhance observability for internal services.