### PR TITLE
Recyclarr

### DIFF
--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -58,10 +58,6 @@ in {
             {template = "sonarr-quality-definition-series";}
             {template = "sonarr-v4-quality-profile-web-1080p";}
             {template = "sonarr-v4-custom-formats-web-1080p";}
-            # anime
-            {template = "sonarr-quality-definition-anime";}
-            {template = "sonarr-v4-quality-profile-anime";}
-            {template = "sonarr-v4-custom-formats-anime";}
           ];
         };
       };

--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -55,8 +55,8 @@ in {
           delete_old_custom_formats = true;
           include = [
             {template = "sonarr-quality-definition-series";}
-            {template = "sonarr-quality-profile-web-1080p-v4";}
-            {template = "sonarr-custom-formats-web-1080p-v4";}
+            {template = "sonarr-v4-quality-profile-web-1080p";}
+            {template = "sonarr-v4-custom-formats-web-1080p";}
           ];
         };
       };

--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -54,9 +54,14 @@ in {
           base_url = "http://localhost:${toString config.services.sonarr.settings.server.port}/";
           delete_old_custom_formats = true;
           include = [
+            # regular
             {template = "sonarr-quality-definition-series";}
             {template = "sonarr-v4-quality-profile-web-1080p";}
             {template = "sonarr-v4-custom-formats-web-1080p";}
+            # anime
+            {template = "sonarr-quality-definition-anime";}
+            {template = "sonarr-v4-quality-profile-anime";}
+            {template = "sonarr-v4-custom-formats-anime"}
           ];
         };
       };

--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -33,15 +33,18 @@ in {
     schedule = "daily";
     configuration = {
       radarr = {
-        main = {
+        movies = {
           api_key = {
             _secret = config.age.secrets."radarr-api-key".path;
           };
           base_url = "http://localhost:${toString config.services.radarr.settings.server.port}/";
+          include = [
+            { template = "radarr-custom-formats-hd-bluray-web"; }
+          ];
         };
       };
       sonarr = {
-        main = {
+        tv = {
           api_key = {
             _secret = config.age.secrets."sonarr-api-key".path;
           };

--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -61,7 +61,7 @@ in {
             # anime
             {template = "sonarr-quality-definition-anime";}
             {template = "sonarr-v4-quality-profile-anime";}
-            {template = "sonarr-v4-custom-formats-anime"}
+            {template = "sonarr-v4-custom-formats-anime";}
           ];
         };
       };

--- a/nixos/sauron/media/default.nix
+++ b/nixos/sauron/media/default.nix
@@ -38,8 +38,11 @@ in {
             _secret = config.age.secrets."radarr-api-key".path;
           };
           base_url = "http://localhost:${toString config.services.radarr.settings.server.port}/";
+          delete_old_custom_formats = true;
           include = [
-            { template = "radarr-custom-formats-hd-bluray-web"; }
+            {template = "radarr-quality-definition-movie";}
+            {template = "radarr-quality-profile-hd-bluray-web";}
+            {template = "radarr-custom-formats-hd-bluray-web";}
           ];
         };
       };
@@ -49,6 +52,12 @@ in {
             _secret = config.age.secrets."sonarr-api-key".path;
           };
           base_url = "http://localhost:${toString config.services.sonarr.settings.server.port}/";
+          delete_old_custom_formats = true;
+          include = [
+            {template = "sonarr-quality-definition-series";}
+            {template = "sonarr-quality-profile-web-1080p-v4";}
+            {template = "sonarr-custom-formats-web-1080p-v4";}
+          ];
         };
       };
     };


### PR DESCRIPTION
This pull request updates the configuration for Radarr and Sonarr in the `nixos/sauron/media/default.nix` file. The main improvement is restructuring the configuration blocks and enhancing them with new quality and custom format templates for both movies and TV series.

Configuration restructuring and enhancements:

* Renamed the Radarr configuration block from `main` to `movies`, and the Sonarr block from `main` to `tv` for better clarity and organization.
* Added `delete_old_custom_formats = true;` to both Radarr and Sonarr configurations to ensure outdated custom formats are removed automatically.
* Included new quality definition and custom format templates for both Radarr (`radarr-quality-definition-movie`, `radarr-quality-profile-hd-bluray-web`, `radarr-custom-formats-hd-bluray-web`) and Sonarr (`sonarr-quality-definition-series`, `sonarr-v4-quality-profile-web-1080p`, `sonarr-v4-custom-formats-web-1080p`).