### PR TITLE
fix(nginx): mitigate HTTP/2 HPACK bomb vulnerability

### DIFF
--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -301,15 +301,15 @@
   # kitty owns graphics protocol (inline images, kitten icat) and OSC 99.
   programs.tmux = {
     enable = true;
-    shortcut = "a";              # prefix = C-a (don't fight readline's C-b)
+    shortcut = "a"; # prefix = C-a (don't fight readline's C-b)
     keyMode = "vi";
     mouse = true;
-    escapeTime = 10;             # snappy mode-key response
+    escapeTime = 10; # snappy mode-key response
     historyLimit = 50000;
-    baseIndex = 1;               # windows/panes start at 1, not 0
+    baseIndex = 1; # windows/panes start at 1, not 0
     terminal = "tmux-256color";
     aggressiveResize = true;
-    sensibleOnTop = true;        # load tmux-sensible defaults under our overrides
+    sensibleOnTop = true; # load tmux-sensible defaults under our overrides
 
     extraConfig = ''
       # TrueColor passthrough for kitty (and any RGB-capable outer terminal)
@@ -346,8 +346,8 @@
     '';
 
     plugins = with pkgs.tmuxPlugins; [
-      sensible           # safer defaults; sensibleOnTop above keeps our overrides
-      yank               # prefix-y to copy selection to system clipboard
+      sensible # safer defaults; sensibleOnTop above keeps our overrides
+      yank # prefix-y to copy selection to system clipboard
       {
         plugin = resurrect;
         extraConfig = ''

--- a/nixos/config/desktop-common.nix
+++ b/nixos/config/desktop-common.nix
@@ -102,7 +102,12 @@
 
   # KDE Connect ports (set up in home-manager/linux.nix for user services.kdeconnect.enable)
   networking.firewall = rec {
-    allowedTCPPortRanges = [ { from = 1714; to = 1764; } ];
+    allowedTCPPortRanges = [
+      {
+        from = 1714;
+        to = 1764;
+      }
+    ];
     allowedUDPPortRanges = allowedTCPPortRanges;
   };
 

--- a/nixos/sauron/nginx/default.nix
+++ b/nixos/sauron/nginx/default.nix
@@ -110,6 +110,20 @@ in {
       directio 4m;
       aio threads;
       output_buffers 2 1m;
+
+      # HTTP/2 HPACK bomb mitigation (CVE-pending, blog.calif.io/p/codex-discovered-a-hidden-http2-bomb)
+      # Caps header count per request — the definitive fix for indexed reference amplification.
+      # Requires nginx >=1.29.8; remove if the build fails on an older version.
+      max_headers 100;
+
+      # Limit concurrent streams to reduce the amplification window per connection.
+      http2_max_concurrent_streams 100;
+
+      # Bound per-request header memory: 4 buffers × 8KB = 32KB ceiling.
+      large_client_header_buffers 4 8k;
+
+      # Drop clients that stall during header transmission (window-stall leg of the attack).
+      client_header_timeout 10s;
     '';
 
     # Only allow PFS-enabled ciphers with AES256


### PR DESCRIPTION
## Summary

- Adds `max_headers 100` directive (nginx >=1.29.8) to cap header fields per request, preventing HPACK indexed reference amplification (~70:1 memory ratio on nginx)
- Adds supporting hardening: `http2_max_concurrent_streams 100`, `large_client_header_buffers 4 8k`, `client_header_timeout 10s`
- Mitigates both legs of the attack: the HPACK bomb itself and the HTTP/2 window stall that pins server memory

## Context

Based on https://blog.calif.io/p/codex-discovered-a-hidden-http2-bomb

## Test plan

- [ ] `nix build .#nixosConfigurations.sauron.config.system.build.toplevel` succeeds (confirms nginx version has `max_headers`)
- [ ] If build fails on `max_headers`, remove that line — remaining directives still provide meaningful hardening
- [ ] Verify nginx starts cleanly after deploy (`systemctl status nginx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)